### PR TITLE
Update URL for 'Join the Community' link

### DIFF
--- a/website/src/page-content/home.config.js
+++ b/website/src/page-content/home.config.js
@@ -11,7 +11,7 @@ export const HomeConfig = {
     },
     {
       name: <>Join the Community</>,
-      url: "https://github.com/finos/fluxnova-modeler/discussions",
+      url: "https://github.com/finos/fluxnova-bpm-platform/discussions",
       style: classnames("secondary"),
     },
   ],


### PR DESCRIPTION
Discussions have been transferred back to the main repo that is now public.