### PR TITLE
Move onBrokenMarkdownLinks to hooks section

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -14,7 +14,6 @@ module.exports = {
   baseUrl: '/',
   onBrokenAnchors: "throw",
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "throw",
   onDuplicateRoutes: "throw",
   trailingSlash: false,
   favicon: 'img/favicon/fluxnova.ico',
@@ -22,6 +21,9 @@ module.exports = {
   organizationName: 'FINOS',
   customFields: {
     repoUrl: `https://github.com/finos/${projectSlug}`,
+  },
+  hooks: {
+      onBrokenMarkdownLinks: 'throw',
   },
   scripts: ['https://buttons.github.io/buttons.js'],
   stylesheets: ['https://fonts.googleapis.com/css?family=Overpass:400,400i,700'],

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -22,8 +22,10 @@ module.exports = {
   customFields: {
     repoUrl: `https://github.com/finos/${projectSlug}`,
   },
-  hooks: {
-      onBrokenMarkdownLinks: 'throw',
+  markdown: {
+    hooks: {
+        onBrokenMarkdownLinks: 'throw',
+    },
   },
   scripts: ['https://buttons.github.io/buttons.js'],
   stylesheets: ['https://fonts.googleapis.com/css?family=Overpass:400,400i,700'],


### PR DESCRIPTION
https://github.com/finos/fluxnova-website/actions/runs/21771371275/job/62819460771?pr=19

```
Warning:  The `siteConfig.onBrokenMarkdownLinks` config option is deprecated and will be removed in Docusaurus v4.
Please migrate and move this option to `siteConfig.markdown.hooks.onBrokenMarkdownLinks` instead.
```