### PR TITLE
fix(homepage): remove floating comma

### DIFF
--- a/website/src/page-content/home.config.js
+++ b/website/src/page-content/home.config.js
@@ -70,7 +70,6 @@ export const HomeConfig = {
           <button className="primary">
             <Link to="https://docs.fluxnova.finos.org">Get Started</Link>
           </button>
-          ,
           <button className="secondary">
             <Link to="https://github.com/finos/fluxnova-bpm-platform/discussions">
               Join the Community


### PR DESCRIPTION
This addresses  #30  the floating comma that appears on the Fluxnova website homepage. 

Before:
<img width="1602" height="703" alt="image" src="https://github.com/user-attachments/assets/4f753901-fd58-47eb-8c5a-8fbdf742fc82" />

After: 
<img width="1660" height="615" alt="image" src="https://github.com/user-attachments/assets/19e7ac1f-15df-40c3-99e1-37a8515ce822" />
